### PR TITLE
Add support for lunar eclipses

### DIFF
--- a/WebGL/webgl_MoonPhasesEclipses.html
+++ b/WebGL/webgl_MoonPhasesEclipses.html
@@ -1068,7 +1068,7 @@
 				{//Earth
 				Earth = new THREE.Mesh( new THREE.SphereGeometry( params.sizeEarth, 32, 32 ), material_Earth );
 // 				Earth.position.x = params.distanceEarthSun;				
-				Earth.castShadow = false;//not to cast shadow on the Moon
+				Earth.castShadow = true; //do cast shadow on the Moon
 				Earth.receiveShadow = true;	
 
 				earth_Heat =  new THREE.Mesh( new THREE.SphereGeometry( params.sizeEarth + 0.6, 32, 32, 3.*Math.PI/2), material_Earth_Heat );//need to start the texture later//not adding it to Earth_pivot -> so no rotations
@@ -1092,7 +1092,7 @@
 				MoonThe = createPlanetShiftTexture( params.distanceMoonEarth, params.sizeMoon, material_Moon );
 // 				MoonThe.rotation.z = obliquityMoon;//moon obliquity 6.7
 				
-				MoonThe.receiveShadow = false;//not to recieve shadow from the Earth
+				MoonThe.receiveShadow = true; //do receive shadow from the Earth
 				MoonThe.castShadow = true;
 
 				MoonAxis = new THREE.Mesh(new THREE.CylinderGeometry( 1, 1, 100, 32, 32 ), moon_axis_material);

--- a/WebGL/webgl_MoonPhasesEclipses.html
+++ b/WebGL/webgl_MoonPhasesEclipses.html
@@ -588,7 +588,7 @@
 					
 					Earth = createPlanet( params.distanceEarthSun , params.sizeEarth , material_Earth);
 					Earth.rotation.y = tempEarthRotation;//remembering the "old" position (rotation around eigen axis)
-					Earth.castShadow = false;
+					Earth.castShadow = true;
 					Earth.receiveShadow = true;
 					
 					Earth_pivot.add( Earth );
@@ -651,7 +651,7 @@
 					MoonThe = createPlanetShiftTexture( params.distanceMoonEarth, params.sizeMoon, material_Moon );
 					MoonThe.rotation.y = tempMoonRotation;//remembering the "old" position (rotation around eigen axis)
 // 					MoonThe.rotation.z = obliquityMoon;//moon obliquity 6.7
-					MoonThe.receiveShadow = false;
+					MoonThe.receiveShadow = true;
 					MoonThe.castShadow = true;
 										
 					Moon_Pivot.add(MoonThe);

--- a/WebGL/webgl_MoonPhasesEclipses.html
+++ b/WebGL/webgl_MoonPhasesEclipses.html
@@ -2030,6 +2030,10 @@
 			];//view
 			}
 			{//load images
+
+			// ensure images can be loaded cross origin (e.g. for serving the app statically through certain CDNs)
+			THREE.ImageUtils.crossOrigin = '';
+
 			var texture_starfield = THREE.ImageUtils.loadTexture( 'Images/Milky2k_flipped.jpg');////flipped (correctly oriented in the code)
 			
 			var texture_shader_star1 =  THREE.ImageUtils.loadTexture( "Images/tex_cloud.png" );

--- a/index.html
+++ b/index.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <meta
+      http-equiv="refresh"
+      content="0; url=./WebGL/webgl_MoonPhasesEclipses.html"
+    />
+  </head>
+</html>


### PR DESCRIPTION
So far, only the Moon would cast shadows onto the Earth. Now, the Earth also casts shadows onto the Moon.